### PR TITLE
Fix module resolution for server code

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage.js";
-import { insertClientSchema } from "@shared/schema";
+import { insertClientSchema } from "../shared/schema.js";
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import type { Client, InsertClient } from "@shared/schema";
+import type { Client, InsertClient } from "../shared/schema.js";
 import pkg from "pg";
 const { Client: PgClient } = pkg;
 


### PR DESCRIPTION
## Summary
- update server imports to use relative paths for shared schemas

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6dd2391c832dab17b23b32c33963